### PR TITLE
Warnings: Uninitialized local variables

### DIFF
--- a/sapnwrfc.c
+++ b/sapnwrfc.c
@@ -384,7 +384,7 @@ static zval * get_time_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	RFC_TIME timeBuff;
-	zval * val;
+	zval * val = NULL;
 
 	rc = RfcGetTime(hcont, name, timeBuff, &errorInfo);
 	if (rc != RFC_OK) {
@@ -406,7 +406,7 @@ static zval * get_date_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	RFC_DATE dateBuff;
-	zval * val;
+	zval * val = NULL;
 
 	rc = RfcGetDate(hcont, name, dateBuff, &errorInfo);
 	if (rc != RFC_OK) {
@@ -428,7 +428,7 @@ static zval * get_int_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	RFC_INT rfc_int;
-	zval * val;
+	zval * val = NULL;
 
 	rc = RfcGetInt(hcont, name, &rfc_int, &errorInfo);
 	if (rc != RFC_OK) {
@@ -449,7 +449,7 @@ static zval * get_int1_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	RFC_INT1 rfc_int1;
-	zval * val;
+	zval * val = NULL;
 
 	rc = RfcGetInt1(hcont, name, &rfc_int1, &errorInfo);
 	if (rc != RFC_OK) {
@@ -470,7 +470,7 @@ static zval * get_int2_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	RFC_INT2 rfc_int2;
-	zval * val;
+	zval * val = NULL;
 
 	rc = RfcGetInt2(hcont, name, &rfc_int2, &errorInfo);
 	if (rc != RFC_OK) {
@@ -491,7 +491,7 @@ static zval * get_float_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	RFC_FLOAT rfc_float;
-	zval * val;
+	zval * val = NULL;
 
 	rc = RfcGetFloat(hcont, name, &rfc_float, &errorInfo);
 	if (rc != RFC_OK) {
@@ -511,7 +511,7 @@ static zval * get_string_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
-	zval * val;
+	zval * val= NULL;
 	unsigned strLen, retStrLen;
 	char * buffer;
 
@@ -552,7 +552,7 @@ static zval * get_xstring_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
-	zval * val;
+	zval * val= NULL;
 	unsigned strLen, retStrLen;
 	char * buffer;
 
@@ -595,7 +595,7 @@ static zval * get_num_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name, unsigned 
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	char * buffer;
-	zval * val;
+	zval * val = NULL;
 
 	buffer = make_space(ulen*2); /* seems that you need 2 null bytes to terminate a string ...*/
 	rc = RfcGetNum(hcont, name, (RFC_NUM *)buffer, ulen, &errorInfo);
@@ -619,7 +619,7 @@ static zval * get_bcd_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
-	zval * val;
+	zval * val = NULL;
 	unsigned strLen, retStrLen;
 	char * buffer;
 
@@ -650,7 +650,7 @@ static zval * get_char_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name, unsigned
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	char * buffer;
-	zval * val;
+	zval * val = NULL;
 
 	buffer = make_space(ulen*4); /* seems that you need 2 null bytes to terminate a string ...*/
 
@@ -676,7 +676,7 @@ static zval * get_byte_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name, unsigned
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
 	char * buffer;
-	zval * val;
+	zval * val = NULL;
 
 	buffer = make_space(len);
 	rc = RfcGetBytes(hcont, name, (SAP_RAW *)buffer, len, &errorInfo);
@@ -704,7 +704,7 @@ static zval * get_structure_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 	RFC_TYPE_DESC_HANDLE typeHandle;
 	RFC_FIELD_DESC fieldDesc;
 	unsigned fieldCount, i;
-	zval * val;
+	zval * val= NULL;
 
 	rc = RfcGetStructure(hcont, name, &line, &errorInfo);
 	if (rc != RFC_OK) {
@@ -843,7 +843,7 @@ static zval * get_table_line(RFC_STRUCTURE_HANDLE line){
 	RFC_TYPE_DESC_HANDLE typeHandle;
 	RFC_FIELD_DESC fieldDesc;
 	unsigned fieldCount, i;
-	zval * val;
+	zval * val = NULL;
 
 	typeHandle = RfcDescribeType(line, &errorInfo);
 	if (typeHandle == NULL) {
@@ -890,7 +890,7 @@ static zval * get_table_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name){
 
 	RFC_RC rc = RFC_OK;
 	RFC_ERROR_INFO errorInfo;
-	zval * val;
+	zval * val = NULL;
 	unsigned tabLen, r;
 	RFC_STRUCTURE_HANDLE line;
 
@@ -927,7 +927,7 @@ static zval * get_parameter_value(zval * name, RFC_FUNCTION_HANDLE funcHandle, R
 	RFC_TABLE_HANDLE tableHandle;
 	RFC_PARAMETER_DESC paramDesc;
 	SAP_UC *p_name;
-	zval * pvalue;
+	zval * pvalue = NULL;
 
 	/* get the parameter description */
 	rc = RfcGetParameterDescByName(funcDescHandle, (p_name = u8to16(name)), &paramDesc, &errorInfo);
@@ -1706,7 +1706,7 @@ static void sapnwrfc_function_object_free_storage(void *object TSRMLS_DC) {
 static zend_object_value sapnwrfc_function_object_new_ex(zend_class_entry *class_type, sapnwrfc_function_object **obj TSRMLS_DC) {
 	zend_object_value retval;
 	sapnwrfc_function_object *intern;
-	zval *tmp;
+	zval *tmp = NULL;
 
 	intern = emalloc(sizeof(sapnwrfc_function_object));
 	memset(intern, 0, sizeof(sapnwrfc_function_object));
@@ -1814,7 +1814,7 @@ static void sapnwrfc_object_free_storage(void *object TSRMLS_DC) {
 static zend_object_value sapnwrfc_object_new_ex(zend_class_entry *class_type, sapnwrfc_object **obj TSRMLS_DC) {
 	zend_object_value retval;
 	sapnwrfc_object *intern;
-	zval *tmp;
+	zval *tmp = NULL;
 
 	intern = emalloc(sizeof(sapnwrfc_object));
 	memset(intern, 0, sizeof(sapnwrfc_object));
@@ -2085,7 +2085,7 @@ PHP_METHOD(sapnwrfc, get_sso_ticket) {
 
 	RFC_ERROR_INFO errorInfo;
 	RFC_RC rc = RFC_OK;
-	SAP_UC * ssoTicket;
+	SAP_UC * ssoTicket = NULL;
 	unsigned length;
 
 	sapnwrfc_global_error = false;


### PR DESCRIPTION
had a lot of such warnings: 

``` cli
Warning 13  warning C4700: uninitialized local variable 'val' used  c:\users\...\downloads\php-sapnwrfc-master\sapnwrfc.c   716 1   php-sapnwrfc
```

With this the warnings are gone -> **_but please double check if it doesnt break anything**_
