### PR TITLE
Fixes the first compile warning

### DIFF
--- a/sapnwrfc.c
+++ b/sapnwrfc.c
@@ -70,7 +70,7 @@ void set_table_value(DATA_CONTAINER_HANDLE hcont, SAP_UC *name, zval * value);
 
 
 /* declare the class entry */
-extern zend_class_entry *zend_ce_iterator;
+extern PHPAPI zend_class_entry *zend_ce_iterator;
 
 #ifdef HAVE_SPL
 extern PHPAPI zend_class_entry *spl_ce_RuntimeException;


### PR DESCRIPTION
https://github.com/piersharding/php-sapnwrfc/issues/5

Warning 1 warning C4273: 'zend_ce_iterator' : inconsistent dll linkage c:\users\downloads\php-sapnwrfc-master\sapnwrfc.c 73 1 php-sapnwrfc

@piersharding be careful and test it. The warning is gone in my enviroment, but i wasnt successfull building the extension until yet.